### PR TITLE
Fixed link to update site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Executes the enhance goal, then refreshes the target folder to prevent workspace
 
 Download the connector plugin using the Eclipse update site at
 
-https://github.com/beskow/openjpa-maven-connector/tree/master/openjpa-connector-update-site
+https://github.com/beskow/openjpa-maven-connector/raw/master/openjpa-connector-update-site


### PR DESCRIPTION
It did not work in eclipse for me before. Inspired by http://stackoverflow.com/questions/2801567/is-it-possible-to-host-an-eclipse-update-site-on-github
